### PR TITLE
Updated documentation and charts for OCP 3.11 support

### DIFF
--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -74,11 +74,11 @@ N/A
 
 **Perform the following for both `order-command-ms` and `order-query-ms` microservices:**
 1. Build and push Docker images
-  1. Create a Jenkins project, pointing to the remote GitHub repository for the Order Microservices, creating the necessary parameters:
+  1. Create a Jenkins project, pointing to the remote GitHub repository for the Order Microservices, creating the necessary parameters.  Refer to the individual microservice's `Jenkinsfile.NoKubernetesPlugin` for appropriate parameter values.
     - Create a String parameter named `REGISTRY` to determine a remote registry that is accessible from your cluster
     - Create a String parameter named `REGISTRY_NAMESPACE` to describe the registry namespace to push image into
-    - Create a String parameter named `IMAGE_NAME` which should be self-expalantory
-    - Create a String parameter named `CONTEXT_DIR` to determine the correct working directory to work from inside the source code, with respect to the root of the repository
+    - Create a String parameter named `IMAGE_NAME` which should be self-expalantory.  Default values should be correct.
+    - Create a String parameter named `CONTEXT_DIR` to determine the correct working directory to work from inside the source code, with respect to the root of the repository.
     - Create a String parameter named `DOCKERFILE` to determine the desired Dockerfile to use to build the Docker image.  This is determined with respect to the `CONTEXT_DIR` parameter.
     - Create a Credentials parameter named `REGISTRY_CREDENTIALS` and assign the necessary credentials to allow Jenkins to push the image to the remote repository
   2. Manually build the Docker image and push it to a registry that is accessible from your cluster (Docker Hub, IBM Cloud Container Registry, manually deployed Quay instance):

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -4,7 +4,7 @@ Be sure to have read the [build and run article before](./build-run.md).
 
 ## Deploy to IKS
 
-Be sure to have [read and done the steps](https://ibm-cloud-architecture.github.io/refarch-kc/analysis/readme/) to prepare the IBM Cloud services and get a kubernetes cluster up and running. 
+Be sure to have [read and done the steps](https://ibm-cloud-architecture.github.io/refarch-kc/analysis/readme/) to prepare the IBM Cloud services and get a kubernetes cluster up and running.
 
 
 Once the two docker images are built, upload them to the IKS private registry
@@ -28,9 +28,9 @@ cd order-command-ms
 
 cd order-query-ms
 ./scripts/deployHelm MINIKUBE
-```   
+```
 
-* Verify the deployments and pods:  
+* Verify the deployments and pods:
 
 ```shell
 kubectl get deployments -n browncompute
@@ -41,7 +41,7 @@ kubectl get deployments -n browncompute
   | kc-ui              |  1  |  1  |  1   |  1  |     18h |
   | ordercommandms-deployment | 1  | 1  | 1  |  1  |   1d |
   | orderqueryms-deployment | 1  |   1 |  1  |  1  |   23h  |
-  | voyagesms-deployment |   1   |  1  |  1  |  1  |   19h |    
+  | voyagesms-deployment |   1   |  1  |  1  |  1  |   19h |
 
 
 ## Deploy to ICP
@@ -69,9 +69,20 @@ N/A
   - Example: `kubectl create secret generic eventstreams-apikey --from-literal=binding='z...12345...notanactualkey...67890...a'`
 
 **Perform the following for both `order-command-ms` and `order-query-ms` microservices:**
-1. Build and push Docker images **TODO**
-  1. Using Jenkfinsfile via pipeline
-  2. Manually
+1. Build and push Docker images
+  1. Create a Jenkins project, pointing to the remote GitHub repository for the Order Microservices, creating the necessary parameters:
+    - Create a String parameter named `REGISTRY` to determine a remote registry that is accessible from your cluster
+    - Create a String parameter named `REGISTRY_NAMESPACE` to describe the registry namespace to push image into
+    - Create a String parameter named `IMAGE_NAME` which should be self-expalantory
+    - Create a String parameter named `CONTEXT_DIR` to determine the correct working directory to work from inside the source code, with respect to the root of the repository
+    - Create a String parameter named `DOCKERFILE` to determine the desired Dockerfile to use to build the Docker image.  This is determined with respect to the `CONTEXT_DIR` parameter.
+    - Create a Credentials parameter named `REGISTRY_CREDENTIALS` and assign the necessary credentials to allow Jenkins to push the image to the remote repository
+  2. Manually build the Docker image and push it to a registry that is accessible from your cluster (Docker Hub, IBM Cloud Container Registry, manually deployed Quay instance):
+    - `docker build -t <private-registry>/<image-namespace>/order-command-ms:latest order-command-ms/`
+    - `docker build -t <private-registry>/<image-namespace>/order-query-ms:latest order-query-ms/`
+    - `docker login <private-registry>`
+    - `docker push <private-registry>/<image-namespace>/order-command-ms:latest`
+    - `docker push <private-registry>/<image-namespace>/order-query-ms:latest`
 3. Generate application YAMLs via `helm template`:
   - Parameters:
     - `--set image.repository=<private-registry>/<image-namespace>/<image-repository>`

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -45,3 +45,43 @@ kubectl get deployments -n browncompute
 
 
 ## Deploy to ICP
+
+N/A
+
+## Deploy to OpenShift Container Platform (OCP)
+
+### Deploy to OCP 3.11
+
+**Cross-component deployment prerequisites:** _(needs to be done once per unique deployment of the entire application)_
+1. If desired, create a non-default Service Account for usage of deploying and running the K Container reference implementation.  This will become more important in future iterations, so it's best to start small:
+  - Command: `oc create serviceaccount -n <target-namespace> kcontainer-runtime`
+  - Example: `oc create serviceaccount -n eda-refarch kcontainer-runtime`
+2. The target Service Account needs to be allowed to run containers as `anyuid` for the time being:
+  - Command: `oc adm policy add-scc-to-user anyuid -z <service-account-name> -n <target-namespace>`
+  - Example: `oc adm policy add-scc-to-user anyuid -z kcontainer-runtime -n eda-refarch`
+  - NOTE: This requires `cluster-admin` level privileges.
+
+2. Create kafka-brokers ConfigMap
+  - Command: `kubectl create configmap kafka-brokers --from-literal=brokers='<replace with comma-separated list of brokers>' -n <namespace>`
+  - Example: `kubectl create configmap kafka-brokers --from-literal=brokers='broker-3-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-2-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-1-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-5-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-0-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-4-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093'`
+3. Create optional eventstreams-apikey Secret
+  - Command: `kubectl create secret generic eventstreams-apikey --from-literal=binding='<replace with api key>' -n <namespace>`
+  - Example: `kubectl create secret generic eventstreams-apikey --from-literal=binding='z...12345...notanactualkey...67890...a'`
+
+**Perform the following for both `order-command-ms` and `order-query-ms` microservices:**
+1. Build and push Docker images **TODO**
+  1. Using Jenkfinsfile via pipeline
+  2. Manually
+3. Generate application YAMLs via `helm template`:
+  - Parameters:
+    - `--set image.repository=<private-registry>/<image-namespace>/<image-repository>`
+    - `--set image.tag=latest`
+    - `--set image.pullSecret=<private-registry-pullsecret>` (optional or set to blank)
+    - `--set image.pullPolicy=Always`
+    - `--set eventstreams.env=ICP`
+    - `--set serviceAccountName=<service-account-name>`
+    - `--namespace <target-namespace>`
+    - `--output-dir <local-template-directory>`
+  - Example: `helm template --set image.repository=rhos-quay.internal-network.local/browncompute/order-command-ms --set image.tag=latest --set image.pullSecret= --set image.pullPolicy=Always --set eventstreams.env=ICP --set serviceAccountName=kcontainer-runtime --output-dir templ --namespace eda-refarch chart/ordercommandms/`
+4. Deploy application using `oc apply`:
+  - `oc apply -f templates/ordercommandms/templates`

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -2,6 +2,17 @@
 
 Be sure to have read the [build and run article before](./build-run.md).
 
+## Deployment prerequisites
+
+Regardless of specific deployment targets (OCP, IKS, k8s), the following prerequisite Kubernetes artifacts need to be created to support the deployments of application components.  These artifacts need to be created once per unique deployment of the entire application and can be shared between application components in the same overall application deployment.
+
+1. Create `kafka-brokers` ConfigMap
+  - Command: `kubectl create configmap kafka-brokers --from-literal=brokers='<replace with comma-separated list of brokers>' -n <namespace>`
+  - Example: `kubectl create configmap kafka-brokers --from-literal=brokers='broker-3-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-2-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-1-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-5-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-0-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-4-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093' -n eda-refarch`
+2. Create optional `eventstreams-apikey` Secret, if you are using Event Streams as your Kafka broker provider
+  - Command: `kubectl create secret generic eventstreams-apikey --from-literal=binding='<replace with api key>' -n <namespace>`
+  - Example: `kubectl create secret generic eventstreams-apikey --from-literal=binding='z...12345...notanactualkey...67890...a' -n eda-refarch`
+
 ## Deploy to IKS
 
 Be sure to have [read and done the steps](https://ibm-cloud-architecture.github.io/refarch-kc/analysis/readme/) to prepare the IBM Cloud services and get a kubernetes cluster up and running.
@@ -60,13 +71,6 @@ N/A
   - Command: `oc adm policy add-scc-to-user anyuid -z <service-account-name> -n <target-namespace>`
   - Example: `oc adm policy add-scc-to-user anyuid -z kcontainer-runtime -n eda-refarch`
   - NOTE: This requires `cluster-admin` level privileges.
-
-2. Create kafka-brokers ConfigMap
-  - Command: `kubectl create configmap kafka-brokers --from-literal=brokers='<replace with comma-separated list of brokers>' -n <namespace>`
-  - Example: `kubectl create configmap kafka-brokers --from-literal=brokers='broker-3-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-2-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-1-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-5-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-0-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-4-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093'`
-3. Create optional eventstreams-apikey Secret
-  - Command: `kubectl create secret generic eventstreams-apikey --from-literal=binding='<replace with api key>' -n <namespace>`
-  - Example: `kubectl create secret generic eventstreams-apikey --from-literal=binding='z...12345...notanactualkey...67890...a'`
 
 **Perform the following for both `order-command-ms` and `order-query-ms` microservices:**
 1. Build and push Docker images

--- a/order-command-ms/Dockerfile.multistage
+++ b/order-command-ms/Dockerfile.multistage
@@ -1,0 +1,55 @@
+### Stage 1 - Java Build
+FROM ibmjava:8-sdk
+LABEL maintainer="IBM Cloud Architecture Solution Engineering at IBM Cloud"
+
+RUN apt-get update && \
+ apt-get -y upgrade && \
+ apt-get install -y vim wget curl git maven
+
+ # attach volumes
+VOLUME /volume/gitrepo
+
+# create working directory
+RUN mkdir -p /local/gitrepo
+WORKDIR /local/gitrepo
+COPY src/ /local/gitrepo/src
+COPY pom.xml /local/gitrepo/pom.xml
+
+RUN mvn install -DskipITs
+
+### Stage 2 - Docker Build
+FROM websphere-liberty:19.0.0.3-microProfile2
+LABEL maintainer="IBM Cloud Architecture Solution Engineering at IBM Cloud"
+# This is the common image for websphere liberty to run only local
+
+USER root
+
+RUN apt-get update -q -y && apt-get dist-upgrade -q -y 
+
+ENV KAFKA_BROKERS=""
+ENV KAFKA_ENV=""
+ENV KAFKA_APIKEY=""
+ENV POSTGRESQL_URL=""
+ENV POSTGRESQL_USER=""
+ENV POSTGRESQL_PWD=""
+
+# 3 next lines need to be there to avoid NPE on javametrics-rest, javametrics-dash,
+COPY --from=0 /local/gitrepo/target/liberty/wlp/usr/servers/defaultServer /config/
+COPY --from=0 /local/gitrepo/target/liberty/wlp/usr/shared/resources /config/resources/
+COPY --from=0 /local/gitrepo/src/main/liberty/config/jvmbx.options /config/jvm.options
+# Grant write access to apps folder, this is to support old and new docker versions.
+# Liberty document reference : https://hub.docker.com/_/websphere-liberty/
+
+USER 1001
+
+# install any missing features required by server config
+RUN installUtility install defaultServer --acceptLicense  
+
+# Upgrade to production license if URL to JAR provided
+ARG LICENSE_JAR_URL
+RUN \ 
+  if [ $LICENSE_JAR_URL ]; then \
+    wget $LICENSE_JAR_URL -O /tmp/license.jar \
+    && java -jar /tmp/license.jar -acceptLicense /opt/ibm \
+    && rm /tmp/license.jar; \
+  fi

--- a/order-command-ms/Jenkinsfile.NoKubernetesPlugin
+++ b/order-command-ms/Jenkinsfile.NoKubernetesPlugin
@@ -50,9 +50,13 @@ pipeline {
                 if [ "${env.REGISTRY}" = "docker.io" ]; then
                     echo 'Pushing to Docker Hub'
                     docker push ${env.IMAGE_NAME}:${env.BUILD_NUMBER}
+                    docker tag ${env.IMAGE_NAME}:${env.BUILD_NUMBER} ${env.IMAGE_NAME}:latest
+                    docker push ${env.IMAGE_NAME}:latest
                 else
                     echo 'Pushing to Private Registry'
                     docker push ${env.REGISTRY}/${env.REGISTRY_NAMESPACE}/${env.IMAGE_NAME}:${env.BUILD_NUMBER}
+                    docker tag ${env.REGISTRY}/${env.REGISTRY_NAMESPACE}/${env.IMAGE_NAME}:${env.BUILD_NUMBER} ${env.REGISTRY}/${env.REGISTRY_NAMESPACE}/${env.IMAGE_NAME}:latest
+                    docker push ${env.REGISTRY}/${env.REGISTRY_NAMESPACE}/${env.IMAGE_NAME}:latest
                 fi
                 """
             }

--- a/order-command-ms/Jenkinsfile.NoKubernetesPlugin
+++ b/order-command-ms/Jenkinsfile.NoKubernetesPlugin
@@ -15,6 +15,7 @@ pipeline {
         string(name: 'REGISTRY_NAMESPACE', defaultValue: 'ibmcase', description: 'registry namespace to push image to')
         string(name: 'IMAGE_NAME', defaultValue: 'bluecompute-web', description: 'name of image')
         string(name: 'DOCKERFILE', defaultValue: 'Dockerfile', description: 'name of Dockerfile for build to use')
+        string(name: 'CONTEXT_DIR', defaultValue: '.', description: 'directory to work from inside source code')
         credentials(name: 'REGISTRY_CREDENTIALS', defaultValue: 'registry-credentials-id', description: 'Credentials for registry', credentialType: 'Username with password')
     }
 
@@ -23,6 +24,8 @@ pipeline {
             steps {
               sh """
               #!/bin/bash
+              cd ${env.CONTEXT_DIR}
+              
               if [ "${env.REGISTRY}" = "docker.io" ]; then
                 echo 'Building Docker Hub Image'
                 docker build -t ${env.IMAGE_NAME}:${env.BUILD_NUMBER} -f ${env.DOCKERFILE} .

--- a/order-command-ms/Jenkinsfile.NoKubernetesPlugin
+++ b/order-command-ms/Jenkinsfile.NoKubernetesPlugin
@@ -1,0 +1,59 @@
+/*
+    To learn how to use this sample pipeline, follow the guide below and enter the
+    corresponding values for your environment and for this repository:
+    - https://github.com/ibm-cloud-architecture/refarch-cloudnative-devops-kubernetes
+*/
+
+pipeline {
+    
+    agent {
+        label "docker"
+    }
+
+    parameters {
+        string(name: 'REGISTRY', defaultValue: 'docker.io', description: 'Container Registry URL')
+        string(name: 'REGISTRY_NAMESPACE', defaultValue: 'ibmcase', description: 'registry namespace to push image to')
+        string(name: 'IMAGE_NAME', defaultValue: 'bluecompute-web', description: 'name of image')
+        credentials(name: 'REGISTRY_CREDENTIALS', defaultValue: 'registry-credentials-id', description: 'Credentials for registry', credentialType: 'Username with password')
+    }
+
+    stages {
+        stage('Build Docker Image') {
+            steps {
+              sh """
+              #!/bin/bash
+              if [ "${env.REGISTRY}" = "docker.io" ]; then
+                echo 'Building Docker Hub Image'
+                docker build -t ${env.IMAGE_NAME}:${env.BUILD_NUMBER} .
+              else
+                echo 'Building Private Registry Image'
+                docker build -t ${env.REGISTRY}/${env.REGISTRY_NAMESPACE}/${env.IMAGE_NAME}:${env.BUILD_NUMBER} .
+              fi
+            """
+            }
+        }
+
+        stage('Push Docker Image to Registry') {
+          steps {
+            withCredentials([usernamePassword(credentialsId: env.REGISTRY_CREDENTIALS,
+                                            usernameVariable: 'USERNAME',
+                                            passwordVariable: 'PASSWORD')]) {
+                sh """
+                #!/bin/bash\
+
+                docker login -u ${USERNAME} -p ${PASSWORD} ${env.REGISTRY}
+
+                if [ "${env.REGISTRY}" = "docker.io" ]; then
+                    echo 'Pushing to Docker Hub'
+                    docker push ${env.IMAGE_NAME}:${env.BUILD_NUMBER}
+                else
+                    echo 'Pushing to Private Registry'
+                    docker push ${env.REGISTRY}/${env.REGISTRY_NAMESPACE}/${env.IMAGE_NAME}:${env.BUILD_NUMBER}
+                fi
+                """
+            }
+          }
+        }
+
+    }
+}

--- a/order-command-ms/Jenkinsfile.NoKubernetesPlugin
+++ b/order-command-ms/Jenkinsfile.NoKubernetesPlugin
@@ -7,9 +7,9 @@ pipeline {
     parameters {
         string(name: 'REGISTRY', defaultValue: 'docker.io', description: 'Container Registry URL')
         string(name: 'REGISTRY_NAMESPACE', defaultValue: 'ibmcase', description: 'registry namespace to push image to')
-        string(name: 'IMAGE_NAME', defaultValue: 'ordercommandms', description: 'name of image')
+        string(name: 'IMAGE_NAME', defaultValue: 'order-command-ms', description: 'name of image')
         string(name: 'DOCKERFILE', defaultValue: 'Dockerfile.multistage', description: 'name of Dockerfile for build to use')
-        string(name: 'CONTEXT_DIR', defaultValue: '.', description: 'directory to work from inside source code')
+        string(name: 'CONTEXT_DIR', defaultValue: 'order-command-ms', description: 'directory to work from inside source code')
         credentials(name: 'REGISTRY_CREDENTIALS', defaultValue: 'registry-credentials-id', description: 'Credentials for registry', credentialType: 'Username with password')
     }
 

--- a/order-command-ms/Jenkinsfile.NoKubernetesPlugin
+++ b/order-command-ms/Jenkinsfile.NoKubernetesPlugin
@@ -14,6 +14,7 @@ pipeline {
         string(name: 'REGISTRY', defaultValue: 'docker.io', description: 'Container Registry URL')
         string(name: 'REGISTRY_NAMESPACE', defaultValue: 'ibmcase', description: 'registry namespace to push image to')
         string(name: 'IMAGE_NAME', defaultValue: 'bluecompute-web', description: 'name of image')
+        string(name: 'DOCKERFILE', defaultValue: 'Dockerfile', description: 'name of Dockerfile for build to use')
         credentials(name: 'REGISTRY_CREDENTIALS', defaultValue: 'registry-credentials-id', description: 'Credentials for registry', credentialType: 'Username with password')
     }
 
@@ -24,10 +25,10 @@ pipeline {
               #!/bin/bash
               if [ "${env.REGISTRY}" = "docker.io" ]; then
                 echo 'Building Docker Hub Image'
-                docker build -t ${env.IMAGE_NAME}:${env.BUILD_NUMBER} .
+                docker build -t ${env.IMAGE_NAME}:${env.BUILD_NUMBER} -f ${env.DOCKERFILE} .
               else
                 echo 'Building Private Registry Image'
-                docker build -t ${env.REGISTRY}/${env.REGISTRY_NAMESPACE}/${env.IMAGE_NAME}:${env.BUILD_NUMBER} .
+                docker build -t ${env.REGISTRY}/${env.REGISTRY_NAMESPACE}/${env.IMAGE_NAME}:${env.BUILD_NUMBER} -f ${env.DOCKERFILE} .
               fi
             """
             }

--- a/order-command-ms/chart/ordercommandms/templates/deployment.yaml
+++ b/order-command-ms/chart/ordercommandms/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
         app: "{{  .Chart.Name }}-selector"
         version: "current"
     spec:
+      serviceAccountName: {{ .Values.serviceAccountName }}
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret }}
       containers:

--- a/order-command-ms/chart/ordercommandms/templates/deployment.yaml
+++ b/order-command-ms/chart/ordercommandms/templates/deployment.yaml
@@ -39,7 +39,10 @@ spec:
           - name: KAFKA_ENV
             value: "{{ .Values.eventstreams.env }}"
           - name: KAFKA_BROKERS
-            value: "{{ .Values.eventstreams.brokers }}"
+            valueFrom:
+              configMapKeyRef:
+                name: "{{ .Values.eventstreams.brokersConfigMap }}"
+                key: brokers
           - name: TRUSTSTORE_PWD
             value: "{{ .Values.java.truststore.pwd }}"
           {{if or (eq .Values.eventstreams.env "IBMCLOUD") (eq .Values.eventstreams.env "ICP")}}

--- a/order-command-ms/chart/ordercommandms/values.yaml
+++ b/order-command-ms/chart/ordercommandms/values.yaml
@@ -46,3 +46,4 @@ eventstreams:
 java:
   truststore:
     pwd: changeit
+serviceAccountName: default

--- a/order-command-ms/chart/ordercommandms/values.yaml
+++ b/order-command-ms/chart/ordercommandms/values.yaml
@@ -38,7 +38,10 @@ istio:
 generatedBindings:
   enabled: true
 eventstreams:
-  brokers: kafka03-prod02.messagehub.services.us-south.bluemix.net:9093,kafka01-prod02.messagehub.services.us-south.bluemix.net:9093,kafka02-prod02.messagehub.services.us-south.bluemix.net:9093,kafka04-prod02.messagehub.services.us-south.bluemix.net:9093,kafka05-prod02.messagehub.services.us-south.bluemix.net:9093
+  brokersConfigMap: kafka-brokers
+  #brokers:
+  #  - kafka01-prod02.messagehub.services.us-south.bluemix.net:9093
+  #  - kafka02-prod02.messagehub.services.us-south.bluemix.net:9093
   env: IBMCLOUD
 java:
   truststore:

--- a/order-query-ms/Dockerfile.multistage
+++ b/order-query-ms/Dockerfile.multistage
@@ -1,0 +1,55 @@
+### Stage 1 - Java Build
+FROM ibmjava:8-sdk
+LABEL maintainer="IBM Cloud Architecture Solution Engineering at IBM Cloud"
+
+RUN apt-get update && \
+ apt-get -y upgrade && \
+ apt-get install -y vim wget curl git maven
+
+ # attach volumes
+VOLUME /volume/gitrepo
+
+# create working directory
+RUN mkdir -p /local/gitrepo
+WORKDIR /local/gitrepo
+COPY src/ /local/gitrepo/src
+COPY pom.xml /local/gitrepo/pom.xml
+
+RUN mvn install -DskipITs
+
+### Stage 2 - Docker Build
+FROM websphere-liberty:19.0.0.3-microProfile2
+LABEL maintainer="IBM Cloud Architecture Solution Engineering at IBM Cloud"
+# This is the common image for websphere liberty to run only local
+
+USER root
+
+RUN apt-get update -q -y && apt-get dist-upgrade -q -y
+
+ENV KAFKA_BROKERS=""
+ENV KAFKA_ENV=""
+ENV KAFKA_APIKEY=""
+ENV POSTGRESQL_URL=""
+ENV POSTGRESQL_USER=""
+ENV POSTGRESQL_PWD=""
+
+# 3 next lines need to be there to avoid NPE on javametrics-rest, javametrics-dash,
+COPY --from=0 /local/gitrepo/target/liberty/wlp/usr/servers/defaultServer /config/
+COPY --from=0 /local/gitrepo/target/liberty/wlp/usr/shared/resources /config/resources/
+COPY --from=0 /local/gitrepo/src/main/liberty/config/jvmbx.options /config/jvm.options
+# Grant write access to apps folder, this is to support old and new docker versions.
+# Liberty document reference : https://hub.docker.com/_/websphere-liberty/
+
+USER 1001
+
+# install any missing features required by server config
+RUN installUtility install defaultServer --acceptLicense
+
+# Upgrade to production license if URL to JAR provided
+ARG LICENSE_JAR_URL
+RUN \
+  if [ $LICENSE_JAR_URL ]; then \
+    wget $LICENSE_JAR_URL -O /tmp/license.jar \
+    && java -jar /tmp/license.jar -acceptLicense /opt/ibm \
+    && rm /tmp/license.jar; \
+  fi

--- a/order-query-ms/Jenkinsfile.NoKubernetesPlugin
+++ b/order-query-ms/Jenkinsfile.NoKubernetesPlugin
@@ -7,9 +7,9 @@ pipeline {
     parameters {
         string(name: 'REGISTRY', defaultValue: 'docker.io', description: 'Container Registry URL')
         string(name: 'REGISTRY_NAMESPACE', defaultValue: 'ibmcase', description: 'registry namespace to push image to')
-        string(name: 'IMAGE_NAME', defaultValue: 'orderqueryms', description: 'name of image')
+        string(name: 'IMAGE_NAME', defaultValue: 'order-query-ms', description: 'name of image')
         string(name: 'DOCKERFILE', defaultValue: 'Dockerfile.multistage', description: 'name of Dockerfile for build to use')
-        string(name: 'CONTEXT_DIR', defaultValue: '.', description: 'directory to work from inside source code')
+        string(name: 'CONTEXT_DIR', defaultValue: 'order-query-ms', description: 'directory to work from inside source code')
         credentials(name: 'REGISTRY_CREDENTIALS', defaultValue: 'registry-credentials-id', description: 'Credentials for registry', credentialType: 'Username with password')
     }
 

--- a/order-query-ms/Jenkinsfile.NoKubernetesPlugin
+++ b/order-query-ms/Jenkinsfile.NoKubernetesPlugin
@@ -7,7 +7,7 @@ pipeline {
     parameters {
         string(name: 'REGISTRY', defaultValue: 'docker.io', description: 'Container Registry URL')
         string(name: 'REGISTRY_NAMESPACE', defaultValue: 'ibmcase', description: 'registry namespace to push image to')
-        string(name: 'IMAGE_NAME', defaultValue: 'ordercommandms', description: 'name of image')
+        string(name: 'IMAGE_NAME', defaultValue: 'orderqueryms', description: 'name of image')
         string(name: 'DOCKERFILE', defaultValue: 'Dockerfile.multistage', description: 'name of Dockerfile for build to use')
         string(name: 'CONTEXT_DIR', defaultValue: '.', description: 'directory to work from inside source code')
         credentials(name: 'REGISTRY_CREDENTIALS', defaultValue: 'registry-credentials-id', description: 'Credentials for registry', credentialType: 'Username with password')

--- a/order-query-ms/chart/orderqueryms/templates/deployment.yaml
+++ b/order-query-ms/chart/orderqueryms/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
         app: "{{  .Chart.Name }}-selector"
         version: "current"
     spec:
+      serviceAccountName: {{ .Values.serviceAccountName }}
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret }}
       containers:
@@ -41,7 +42,10 @@ spec:
           - name: KAFKA_ENV
             value: "{{ .Values.eventstreams.env }}"
           - name: KAFKA_BROKERS
-            value: "{{ .Values.eventstreams.brokers }}"
+            valueFrom:
+              configMapKeyRef:
+                name: "{{ .Values.eventstreams.brokersConfigMap }}"
+                key: brokers
           {{if or (eq .Values.eventstreams.env "IBMCLOUD") (eq .Values.eventstreams.env "ICP")}}
           - name: KAFKA_APIKEY
             valueFrom:

--- a/order-query-ms/chart/orderqueryms/values.yaml
+++ b/order-query-ms/chart/orderqueryms/values.yaml
@@ -38,8 +38,12 @@ istio:
 generatedBindings:
   enabled: true
 eventstreams:
-  brokers: kafka03-prod02.messagehub.services.us-south.bluemix.net:9093,kafka01-prod02.messagehub.services.us-south.bluemix.net:9093,kafka02-prod02.messagehub.services.us-south.bluemix.net:9093,kafka04-prod02.messagehub.services.us-south.bluemix.net:9093,kafka05-prod02.messagehub.services.us-south.bluemix.net:9093
+  brokersConfigMap: kafka-brokers
+  #brokers:
+  #  - kafka03-prod02.messagehub.services.us-south.bluemix.net:9093
+  #  - kafka01-prod02.messagehub.services.us-south.bluemix.net:9093
   env: IBMCLOUD
 java:
   truststore:
     pwd: changeit
+serviceAccountName: default


### PR DESCRIPTION
Updated documentation for deployment to OCP 3.11, as well as moved kafka-broker definition into a ConfigMap and updated Chart files to accommodate.