### PR TITLE
Implemented Event Streams on ICP & documentation refactored

### DIFF
--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -104,7 +104,7 @@ N/A
     - `--output-dir <local-template-directory>`
   - Example using Event Streams via ICP4I:
    ```shell
-   helm template --set image.repository=rhos-quay.internal-network.local/browncompute/order-command-ms --set image.pullSecret= --set kafka.brokersConfigMap=es-kafka-brokers --set eventstreams.enabled=true --set eventstreams.apikeyConfigMap=es-eventstreams-apikey --set serviceAccountName=kcontainer-runtime --set eventstreams.truststoreRequired=true --set eventstreams.truststoreSecret=es-ca-pemfile --set eventstreams.truststorePassword=password --output-dir templates --namespace eda-pipelines-sandbox chart/ordercommandms
+   helm template --set image.repository=rhos-quay.internal-network.local/browncompute/order-command-ms --set image.pullSecret= --set kafka.brokersConfigMap=es-kafka-brokers --set eventstreams.enabled=true --set eventstreams.apikeyConfigMap=es-eventstreams-apikey --set serviceAccountName=kcontainer-runtime --set eventstreams.truststoreRequired=true --set eventstreams.truststoreSecret=es-truststore-jks --set eventstreams.truststorePassword=password --output-dir templates --namespace eda-pipelines-sandbox chart/ordercommandms
    ```
   - Example using Event Streams hosted on IBM Cloud:
    ```shell

--- a/order-command-ms/Dockerfile.multistage
+++ b/order-command-ms/Dockerfile.multistage
@@ -15,7 +15,7 @@ WORKDIR /local/gitrepo
 COPY src/ /local/gitrepo/src
 COPY pom.xml /local/gitrepo/pom.xml
 
-RUN mvn install -DskipITs
+RUN mvn install -DskipTests=true
 
 ### Stage 2 - Docker Build
 FROM websphere-liberty:19.0.0.3-microProfile2
@@ -24,7 +24,7 @@ LABEL maintainer="IBM Cloud Architecture Solution Engineering at IBM Cloud"
 
 USER root
 
-RUN apt-get update -q -y && apt-get dist-upgrade -q -y 
+RUN apt-get update -q -y && apt-get dist-upgrade -q -y
 
 ENV KAFKA_BROKERS=""
 ENV KAFKA_ENV=""
@@ -43,11 +43,11 @@ COPY --from=0 /local/gitrepo/src/main/liberty/config/jvmbx.options /config/jvm.o
 USER 1001
 
 # install any missing features required by server config
-RUN installUtility install defaultServer --acceptLicense  
+RUN installUtility install defaultServer --acceptLicense
 
 # Upgrade to production license if URL to JAR provided
 ARG LICENSE_JAR_URL
-RUN \ 
+RUN \
   if [ $LICENSE_JAR_URL ]; then \
     wget $LICENSE_JAR_URL -O /tmp/license.jar \
     && java -jar /tmp/license.jar -acceptLicense /opt/ibm \

--- a/order-command-ms/chart/ordercommandms/templates/deployment.yaml
+++ b/order-command-ms/chart/ordercommandms/templates/deployment.yaml
@@ -37,8 +37,6 @@ spec:
             value: "{{ .Values.service.servicePort }}"
           - name: APPLICATION_NAME
             value: "{{ .Release.Name }}"
-          #- name: KAFKA_ENV
-          #  value: "{{ .Values.eventstreams.env }}"
           - name: KAFKA_BROKERS
             valueFrom:
               configMapKeyRef:

--- a/order-command-ms/chart/ordercommandms/templates/deployment.yaml
+++ b/order-command-ms/chart/ordercommandms/templates/deployment.yaml
@@ -37,40 +37,40 @@ spec:
             value: "{{ .Values.service.servicePort }}"
           - name: APPLICATION_NAME
             value: "{{ .Release.Name }}"
-          - name: KAFKA_ENV
-            value: "{{ .Values.eventstreams.env }}"
+          #- name: KAFKA_ENV
+          #  value: "{{ .Values.eventstreams.env }}"
           - name: KAFKA_BROKERS
             valueFrom:
               configMapKeyRef:
-                name: "{{ .Values.eventstreams.brokersConfigMap }}"
+                name: "{{ .Values.kafka.brokersConfigMap }}"
                 key: brokers
-          {{- if or (eq .Values.eventstreams.env "IBMCLOUD") (eq .Values.eventstreams.env "ICP") }}
+          {{- if .Values.eventstreams.enabled }}
           - name: KAFKA_APIKEY
             valueFrom:
               secretKeyRef:
                 name: "{{ .Values.eventstreams.apikeyConfigMap }}"
                 key: binding
           {{- end }}
-          {{- if .Values.java.truststore.enabled }}
+          {{- if .Values.eventstreams.truststoreRequired }}
           - name: TRUSTSTORE_ENABLED
-            value: "{{ .Values.java.truststore.enabled }}"
+            value: "{{ .Values.eventstreams.truststoreRequired }}"
           - name: TRUSTSTORE_PWD
-            value: "{{ .Values.java.truststore.pwd }}"
+            value: "{{ .Values.eventstreams.truststorePassword }}"
           - name: TRUSTSTORE_PATH
-            value: "{{ .Values.java.truststore.pathName }}/{{ .Values.java.truststore.fileName }}"
+            value: "{{ .Values.eventstreams.truststorePath }}/{{ .Values.eventstreams.truststoreFile }}"
           {{- end }}
 {{- if .Values.generatedBindings.enabled }}
 {{.Files.Get "bindings.yaml" | indent 10 }}
 {{- end }}
-        {{- if .Values.java.truststore.enabled }}
+        {{- if .Values.eventstreams.truststoreRequired }}
         volumeMounts:
-          - mountPath: "{{ .Values.java.truststore.pathName }}"
+          - mountPath: "{{ .Values.eventstreams.truststorePath }}"
             name: eventstreams-truststore
             readOnly: true
         {{- end }}
-      {{- if .Values.java.truststore.enabled }}
+      {{- if .Values.eventstreams.truststoreRequired }}
       volumes:
         - name: eventstreams-truststore
           secret:
-            secretName: "{{ .Values.java.truststore.secretName }}"
+            secretName: "{{ .Values.eventstreams.truststoreSecret }}"
       {{- end }}

--- a/order-command-ms/chart/ordercommandms/templates/deployment.yaml
+++ b/order-command-ms/chart/ordercommandms/templates/deployment.yaml
@@ -44,15 +44,33 @@ spec:
               configMapKeyRef:
                 name: "{{ .Values.eventstreams.brokersConfigMap }}"
                 key: brokers
-          - name: TRUSTSTORE_PWD
-            value: "{{ .Values.java.truststore.pwd }}"
-          {{if or (eq .Values.eventstreams.env "IBMCLOUD") (eq .Values.eventstreams.env "ICP")}}
+          {{- if or (eq .Values.eventstreams.env "IBMCLOUD") (eq .Values.eventstreams.env "ICP") }}
           - name: KAFKA_APIKEY
             valueFrom:
               secretKeyRef:
                 name: "{{ .Values.eventstreams.apikeyConfigMap }}"
                 key: binding
-          {{end}}
+          {{- end }}
+          {{- if .Values.java.truststore.enabled }}
+          - name: TRUSTSTORE_ENABLED
+            value: "{{ .Values.java.truststore.enabled }}"
+          - name: TRUSTSTORE_PWD
+            value: "{{ .Values.java.truststore.pwd }}"
+          - name: TRUSTSTORE_PATH
+            value: "{{ .Values.java.truststore.pathName }}/{{ .Values.java.truststore.fileName }}"
+          {{- end }}
 {{- if .Values.generatedBindings.enabled }}
 {{.Files.Get "bindings.yaml" | indent 10 }}
 {{- end }}
+        {{- if .Values.java.truststore.enabled }}
+        volumeMounts:
+          - mountPath: "{{ .Values.java.truststore.pathName }}"
+            name: eventstreams-truststore
+            readOnly: true
+        {{- end }}
+      {{- if .Values.java.truststore.enabled }}
+      volumes:
+        - name: eventstreams-truststore
+          secret:
+            secretName: "{{ .Values.java.truststore.secretName }}"
+      {{- end }}

--- a/order-command-ms/chart/ordercommandms/values.yaml
+++ b/order-command-ms/chart/ordercommandms/values.yaml
@@ -39,20 +39,6 @@ generatedBindings:
   enabled: true
 kafka:
   brokersConfigMap: kafka-brokers
-
-eventstreams:
-  brokersConfigMap: kafka-brokers
-  apikeyConfigMap: eventstreams-apikey
-  env: IBMCLOUD
-java:
-  truststore:
-    enabled: false
-    pathName: /opt/ibm/wlp/usr/shared/resources/es-ssl
-    fileName: es-cert.jks
-    secretName: es-truststore-jks
-    pwd: changeit
-
-
 eventstreams:
   enabled: true
   apikeyConfigMap: eventstreams-apikey

--- a/order-command-ms/chart/ordercommandms/values.yaml
+++ b/order-command-ms/chart/ordercommandms/values.yaml
@@ -46,5 +46,9 @@ eventstreams:
   env: IBMCLOUD
 java:
   truststore:
+    enabled: false
+    pathName: /opt/ibm/wlp/usr/shared/resources/es-ssl
+    fileName: es-cert.jks
+    secretName: es-truststore-jks
     pwd: changeit
 serviceAccountName: default

--- a/order-command-ms/chart/ordercommandms/values.yaml
+++ b/order-command-ms/chart/ordercommandms/values.yaml
@@ -37,12 +37,12 @@ istio:
   weight: 100
 generatedBindings:
   enabled: true
+kafka:
+  brokersConfigMap: kafka-brokers
+
 eventstreams:
   brokersConfigMap: kafka-brokers
   apikeyConfigMap: eventstreams-apikey
-  #brokers:
-  #  - kafka01-prod02.messagehub.services.us-south.bluemix.net:9093
-  #  - kafka02-prod02.messagehub.services.us-south.bluemix.net:9093
   env: IBMCLOUD
 java:
   truststore:
@@ -51,4 +51,14 @@ java:
     fileName: es-cert.jks
     secretName: es-truststore-jks
     pwd: changeit
+
+
+eventstreams:
+  enabled: true
+  apikeyConfigMap: eventstreams-apikey
+  truststoreRequired: false
+  truststorePath: /config/resources/security/es-ssl
+  truststoreFile: es-cert.jks
+  truststoreSecret: es-truststore-jks
+  truststorePassword: changeit
 serviceAccountName: default

--- a/order-command-ms/src/main/java/ibm/labs/kc/order/command/kafka/ApplicationConfig.java
+++ b/order-command-ms/src/main/java/ibm/labs/kc/order/command/kafka/ApplicationConfig.java
@@ -66,34 +66,25 @@ public class ApplicationConfig {
         Properties properties = new Properties();
         Map<String, String> env = System.getenv();
 
-        if ("IBMCLOUD".equals(env.get("KAFKA_ENV")) || "ICP".equals(env.get("KAFKA_ENV"))) {
-            if (env.get("KAFKA_BROKERS") == null) {
-                throw new IllegalStateException("Missing environment variable KAFKA_BROKERS");
-            }
-            if (env.get("KAFKA_APIKEY") == null) {
-                throw new IllegalStateException("Missing environment variable KAFKA_APIKEY");
-            }
-            properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, env.get("KAFKA_BROKERS"));
-            properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-            properties.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
-            properties.put(SaslConfigs.SASL_JAAS_CONFIG,
+        if (env.get("KAFKA_BROKERS") == null) {
+            throw new IllegalStateException("Missing environment variable KAFKA_BROKERS");
+        }
+        properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, env.get("KAFKA_BROKERS"));
+
+    		if (env.get("KAFKA_APIKEY") != null) {
+          properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+          properties.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+          properties.put(SaslConfigs.SASL_JAAS_CONFIG,
                     "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\""
                             + env.get("KAFKA_APIKEY") + "\";");
-            properties.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
-            properties.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, "TLSv1.2");
-            properties.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
+          properties.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
+          properties.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, "TLSv1.2");
+          properties.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
 
-            if ("true".equals(env.get("TRUSTSTORE_ENABLED"))){
-              properties.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, env.get("TRUSTSTORE_PATH"));
-              properties.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, env.get("TRUSTSTORE_PWD"));
-            }
-
-        } else {
-            if (env.get("KAFKA_BROKERS") == null) {
-                properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-            } else {
-                properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, env.get("KAFKA_BROKERS"));
-            }
+          if ("true".equals(env.get("TRUSTSTORE_ENABLED"))){
+            properties.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, env.get("TRUSTSTORE_PATH"));
+            properties.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, env.get("TRUSTSTORE_PWD"));
+          }
         }
 
         return properties;

--- a/order-command-ms/src/main/java/ibm/labs/kc/order/command/kafka/ApplicationConfig.java
+++ b/order-command-ms/src/main/java/ibm/labs/kc/order/command/kafka/ApplicationConfig.java
@@ -59,7 +59,7 @@ public class ApplicationConfig {
 
     /**
      * Take into account the environment variables if set
-     * 
+     *
      * @return common kafka properties
      */
     private static Properties buildCommonProperties() {
@@ -82,6 +82,12 @@ public class ApplicationConfig {
             properties.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
             properties.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, "TLSv1.2");
             properties.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
+
+            if ("true".equals(env.get("TRUSTSTORE_ENABLED"))){
+              properties.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, env.get("TRUSTSTORE_PATH"));
+              properties.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, env.get("TRUSTSTORE_PWD"));
+            }
+
         } else {
             if (env.get("KAFKA_BROKERS") == null) {
                 properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");

--- a/order-query-ms/Dockerfile.multistage
+++ b/order-query-ms/Dockerfile.multistage
@@ -15,7 +15,7 @@ WORKDIR /local/gitrepo
 COPY src/ /local/gitrepo/src
 COPY pom.xml /local/gitrepo/pom.xml
 
-RUN mvn install -DskipITs
+RUN mvn install -DskipTests=true
 
 ### Stage 2 - Docker Build
 FROM websphere-liberty:19.0.0.3-microProfile2

--- a/order-query-ms/chart/orderqueryms/templates/deployment.yaml
+++ b/order-query-ms/chart/orderqueryms/templates/deployment.yaml
@@ -37,8 +37,6 @@ spec:
             value: "{{ .Values.service.servicePort }}"
           - name: APPLICATION_NAME
             value: "{{ .Release.Name }}"
-          - name: TRUSTSTORE_PWD
-            value: "{{ .Values.java.truststore.pwd }}"
           - name: KAFKA_ENV
             value: "{{ .Values.eventstreams.env }}"
           - name: KAFKA_BROKERS
@@ -46,13 +44,33 @@ spec:
               configMapKeyRef:
                 name: "{{ .Values.eventstreams.brokersConfigMap }}"
                 key: brokers
-          {{if or (eq .Values.eventstreams.env "IBMCLOUD") (eq .Values.eventstreams.env "ICP")}}
+          {{- if or (eq .Values.eventstreams.env "IBMCLOUD") (eq .Values.eventstreams.env "ICP") }}
           - name: KAFKA_APIKEY
             valueFrom:
               secretKeyRef:
                 name: "{{ .Values.eventstreams.apikeyConfigMap }}"
                 key: binding
-          {{end}}
+          {{- end }}
+          {{- if .Values.java.truststore.enabled }}
+          - name: TRUSTSTORE_ENABLED
+            value: "{{ .Values.java.truststore.enabled }}"
+          - name: TRUSTSTORE_PWD
+            value: "{{ .Values.java.truststore.pwd }}"
+          - name: TRUSTSTORE_PATH
+            value: "{{ .Values.java.truststore.pathName }}/{{ .Values.java.truststore.fileName }}"
+          {{- end }}
 {{- if .Values.generatedBindings.enabled }}
 {{.Files.Get "bindings.yaml" | indent 10 }}
 {{- end }}
+        {{- if .Values.java.truststore.enabled }}
+        volumeMounts:
+          - mountPath: "{{ .Values.java.truststore.pathName }}"
+            name: eventstreams-truststore
+            readOnly: true
+        {{- end }}
+      {{- if .Values.java.truststore.enabled }}
+      volumes:
+        - name: eventstreams-truststore
+          secret:
+            secretName: "{{ .Values.java.truststore.secretName }}"
+      {{- end }}

--- a/order-query-ms/chart/orderqueryms/templates/deployment.yaml
+++ b/order-query-ms/chart/orderqueryms/templates/deployment.yaml
@@ -37,40 +37,38 @@ spec:
             value: "{{ .Values.service.servicePort }}"
           - name: APPLICATION_NAME
             value: "{{ .Release.Name }}"
-          - name: KAFKA_ENV
-            value: "{{ .Values.eventstreams.env }}"
           - name: KAFKA_BROKERS
             valueFrom:
               configMapKeyRef:
-                name: "{{ .Values.eventstreams.brokersConfigMap }}"
+                name: "{{ .Values.kafka.brokersConfigMap }}"
                 key: brokers
-          {{- if or (eq .Values.eventstreams.env "IBMCLOUD") (eq .Values.eventstreams.env "ICP") }}
+          {{- if .Values.eventstreams.enabled }}
           - name: KAFKA_APIKEY
             valueFrom:
               secretKeyRef:
                 name: "{{ .Values.eventstreams.apikeyConfigMap }}"
                 key: binding
           {{- end }}
-          {{- if .Values.java.truststore.enabled }}
+          {{- if .Values.eventstreams.truststoreRequired }}
           - name: TRUSTSTORE_ENABLED
-            value: "{{ .Values.java.truststore.enabled }}"
+            value: "{{ .Values.eventstreams.truststoreRequired }}"
           - name: TRUSTSTORE_PWD
-            value: "{{ .Values.java.truststore.pwd }}"
+            value: "{{ .Values.eventstreams.truststorePassword }}"
           - name: TRUSTSTORE_PATH
-            value: "{{ .Values.java.truststore.pathName }}/{{ .Values.java.truststore.fileName }}"
+            value: "{{ .Values.eventstreams.truststorePath }}/{{ .Values.eventstreams.truststoreFile }}"
           {{- end }}
 {{- if .Values.generatedBindings.enabled }}
 {{.Files.Get "bindings.yaml" | indent 10 }}
 {{- end }}
-        {{- if .Values.java.truststore.enabled }}
+        {{- if .Values.eventstreams.truststoreRequired }}
         volumeMounts:
-          - mountPath: "{{ .Values.java.truststore.pathName }}"
+          - mountPath: "{{ .Values.eventstreams.truststorePath }}"
             name: eventstreams-truststore
             readOnly: true
         {{- end }}
-      {{- if .Values.java.truststore.enabled }}
+      {{- if .Values.eventstreams.truststoreRequired }}
       volumes:
         - name: eventstreams-truststore
           secret:
-            secretName: "{{ .Values.java.truststore.secretName }}"
+            secretName: "{{ .Values.eventstreams.truststoreSecret }}"
       {{- end }}

--- a/order-query-ms/chart/orderqueryms/values.yaml
+++ b/order-query-ms/chart/orderqueryms/values.yaml
@@ -46,5 +46,9 @@ eventstreams:
   env: IBMCLOUD
 java:
   truststore:
+    enabled: false
+    pathName: /opt/ibm/wlp/usr/shared/resources/es-ssl
+    fileName: es-cert.jks
+    secretName: es-truststore-jks
     pwd: changeit
 serviceAccountName: default

--- a/order-query-ms/chart/orderqueryms/values.yaml
+++ b/order-query-ms/chart/orderqueryms/values.yaml
@@ -37,18 +37,14 @@ istio:
   weight: 100
 generatedBindings:
   enabled: true
-eventstreams:
+kafka:
   brokersConfigMap: kafka-brokers
+eventstreams:
+  enabled: true
   apikeyConfigMap: eventstreams-apikey
-  #brokers:
-  #  - kafka03-prod02.messagehub.services.us-south.bluemix.net:9093
-  #  - kafka01-prod02.messagehub.services.us-south.bluemix.net:9093
-  env: IBMCLOUD
-java:
-  truststore:
-    enabled: false
-    pathName: /opt/ibm/wlp/usr/shared/resources/es-ssl
-    fileName: es-cert.jks
-    secretName: es-truststore-jks
-    pwd: changeit
+  truststoreRequired: false
+  truststorePath: /config/resources/security/es-ssl
+  truststoreFile: es-cert.jks
+  truststoreSecret: es-truststore-jks
+  truststorePassword: changeit
 serviceAccountName: default

--- a/order-query-ms/src/main/java/ibm/labs/kc/order/query/kafka/ApplicationConfig.java
+++ b/order-query-ms/src/main/java/ibm/labs/kc/order/query/kafka/ApplicationConfig.java
@@ -53,7 +53,7 @@ public class ApplicationConfig {
         properties.put(ConsumerConfig.CLIENT_ID_CONFIG, "order-query-reload");
         return properties;
     }
-    
+
     public static Properties getContainerConsumerProperties(String groupid) {
         Properties properties = buildCommonProperties();
         properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupid);
@@ -105,6 +105,12 @@ public class ApplicationConfig {
             properties.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
             properties.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, "TLSv1.2");
             properties.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
+
+            if ("true".equals(env.get("TRUSTSTORE_ENABLED"))){
+              properties.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, env.get("TRUSTSTORE_PATH"));
+              properties.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, env.get("TRUSTSTORE_PWD"));
+            }
+            
         } else {
             if (env.get("KAFKA_BROKERS") == null) {
                 properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");

--- a/order-query-ms/src/main/java/ibm/labs/kc/order/query/kafka/ApplicationConfig.java
+++ b/order-query-ms/src/main/java/ibm/labs/kc/order/query/kafka/ApplicationConfig.java
@@ -89,34 +89,25 @@ public class ApplicationConfig {
         Properties properties = new Properties();
         Map<String, String> env = System.getenv();
 
-        if ("IBMCLOUD".equals(env.get("KAFKA_ENV")) || "ICP".equals(env.get("KAFKA_ENV"))) {
-            if (env.get("KAFKA_BROKERS") == null) {
-                throw new IllegalStateException("Missing environment variable KAFKA_BROKERS");
-            }
-            if (env.get("KAFKA_APIKEY") == null) {
-                throw new IllegalStateException("Missing environment variable KAFKA_APIKEY");
-            }
-            properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, env.get("KAFKA_BROKERS"));
-            properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-            properties.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
-            properties.put(SaslConfigs.SASL_JAAS_CONFIG,
+        if (env.get("KAFKA_BROKERS") == null) {
+            throw new IllegalStateException("Missing environment variable KAFKA_BROKERS");
+        }
+        properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, env.get("KAFKA_BROKERS"));
+
+    		if (env.get("KAFKA_APIKEY") != null) {
+          properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+          properties.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+          properties.put(SaslConfigs.SASL_JAAS_CONFIG,
                     "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\""
                             + env.get("KAFKA_APIKEY") + "\";");
-            properties.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
-            properties.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, "TLSv1.2");
-            properties.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
+          properties.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
+          properties.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, "TLSv1.2");
+          properties.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
 
-            if ("true".equals(env.get("TRUSTSTORE_ENABLED"))){
-              properties.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, env.get("TRUSTSTORE_PATH"));
-              properties.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, env.get("TRUSTSTORE_PWD"));
-            }
-            
-        } else {
-            if (env.get("KAFKA_BROKERS") == null) {
-                properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-            } else {
-                properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, env.get("KAFKA_BROKERS"));
-            }
+          if ("true".equals(env.get("TRUSTSTORE_ENABLED"))){
+            properties.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, env.get("TRUSTSTORE_PATH"));
+            properties.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, env.get("TRUSTSTORE_PWD"));
+          }
         }
 
         return properties;


### PR DESCRIPTION
Implemented Event Streams on ICP support, which requires explicit PEM or JKS file integration. This edit includes a dynamic ConfigMap & Secret injection into the pod, based upon Helm chart values.

This PR also removes the KAFKA_ENV variable for more explicit Helm values, allowing for easier, more explicit support of any Kafka or Event Streams deployment anywhere.