### PR TITLE
Fix unit tests

### DIFF
--- a/order-command-ms/Dockerfile.multistage
+++ b/order-command-ms/Dockerfile.multistage
@@ -14,7 +14,7 @@ WORKDIR /local/gitrepo
 COPY src/ /local/gitrepo/src
 COPY pom.xml /local/gitrepo/pom.xml
 
-RUN mvn install -DskipTests=true
+RUN mvn install -DskipITs
 
 ### Stage 2 - Docker Build
 FROM open-liberty:microProfile3-java11

--- a/order-command-ms/src/main/java/ibm/gse/orderms/infrastructure/kafka/ErrorEventProducer.java
+++ b/order-command-ms/src/main/java/ibm/gse/orderms/infrastructure/kafka/ErrorEventProducer.java
@@ -30,8 +30,10 @@ public class ErrorEventProducer implements EventEmitterTransactional {
 
     private KafkaProducer<String, String> kafkaProducer;
     private Properties properties;
+    private KafkaInfrastructureConfig config;
 
     public ErrorEventProducer() {
+        config = new KafkaInfrastructureConfig();
         initProducer();
     }
 
@@ -72,7 +74,7 @@ public class ErrorEventProducer implements EventEmitterTransactional {
         ErrorEvent errorEvent = (ErrorEvent) event;
         String value = new Gson().toJson(errorEvent);
 
-        ProducerRecord<String, String> record = new ProducerRecord<>(KafkaInfrastructureConfig.getErrorTopic(), value);
+        ProducerRecord<String, String> record = new ProducerRecord<>(config.getErrorTopic(), value);
 
         kafkaProducer.beginTransaction();
         Future<RecordMetadata> send = kafkaProducer.send(record);

--- a/order-command-ms/src/main/java/ibm/gse/orderms/infrastructure/kafka/KafkaInfrastructureConfig.java
+++ b/order-command-ms/src/main/java/ibm/gse/orderms/infrastructure/kafka/KafkaInfrastructureConfig.java
@@ -24,7 +24,7 @@ public class KafkaInfrastructureConfig {
 
 	private static final Logger logger = LoggerFactory.getLogger(KafkaInfrastructureConfig.class.getName());
 
-	private static Config config = ConfigProvider.getConfig();
+	private Config config;
 
 	private static String ORDER_TOPIC;
 
@@ -40,19 +40,23 @@ public class KafkaInfrastructureConfig {
 	// TODO this is temporary once we use schema registry
 	public static final String SCHEMA_VERSION = "1";
 
-	public static String getOrderTopic() {
+	public KafkaInfrastructureConfig() {
+		config = ConfigProvider.getConfig();
+	}
+
+	public String getOrderTopic() {
 		ORDER_TOPIC = config.getValue("order.topic", String.class);
 		logger.info("Get Order Topic: {}", ORDER_TOPIC);
 		return ORDER_TOPIC;
 	}
 
-	public static String getOrderCommandTopic() {
+	public String getOrderCommandTopic() {
 		ORDER_COMMAND_TOPIC = config.getValue("ordercommand.topic", String.class);
 		logger.info("Get Order Command Topic: {}", ORDER_COMMAND_TOPIC);
 		return ORDER_COMMAND_TOPIC;
 	}
 
-	public static String getErrorTopic() {
+	public String getErrorTopic() {
 		ERROR_TOPIC = config.getValue("error.topic",  String.class);
 		logger.info("Get Error Topic: {}", ERROR_TOPIC);
 		return ERROR_TOPIC;

--- a/order-command-ms/src/main/java/ibm/gse/orderms/infrastructure/kafka/OrderCommandProducer.java
+++ b/order-command-ms/src/main/java/ibm/gse/orderms/infrastructure/kafka/OrderCommandProducer.java
@@ -27,8 +27,10 @@ public class OrderCommandProducer implements EventEmitter  {
 	
 	private KafkaProducer<String, String> kafkaProducer;
 	private Properties properties;
+	private KafkaInfrastructureConfig config;
     
     public OrderCommandProducer() {
+		config = new KafkaInfrastructureConfig();
     	initProducer();
     }
     
@@ -60,7 +62,7 @@ public class OrderCommandProducer implements EventEmitter  {
         String value = new Gson().toJson(orderCommandEvent);
         
         try {
-	        ProducerRecord<String, String> record = new ProducerRecord<>(KafkaInfrastructureConfig.getOrderCommandTopic(), key, value);
+	        ProducerRecord<String, String> record = new ProducerRecord<>(config.getOrderCommandTopic(), key, value);
 			Future<RecordMetadata> send = kafkaProducer.send(record);
 	        logger.info("Command event sent: " + value);
 	        send.get(KafkaInfrastructureConfig.PRODUCER_TIMEOUT_SECS, TimeUnit.SECONDS);

--- a/order-command-ms/src/main/java/ibm/gse/orderms/infrastructure/kafka/OrderEventAgent.java
+++ b/order-command-ms/src/main/java/ibm/gse/orderms/infrastructure/kafka/OrderEventAgent.java
@@ -50,6 +50,7 @@ public class OrderEventAgent implements EventListener {
     private static final Logger logger = LoggerFactory.getLogger(OrderEventAgent.class.getName());
 	private final KafkaConsumer<String, String> kafkaConsumer;
 	private EventEmitter orderEventProducer; // Need to produce OrderRejected Events
+	private KafkaInfrastructureConfig config;
     private final ShippingOrderRepository orderRepository; 
     private static final Gson gson = new Gson();
     private Duration pollTimeOut;
@@ -62,8 +63,9 @@ public class OrderEventAgent implements EventListener {
 		// Using a value of read_committed ensures that we don't read any transactional
 		// messages before the transaction from OrderCommandAgent to create, update or reject an order completes.
 		properties.put("isolation.level", "read_committed");
-        kafkaConsumer = new KafkaConsumer<String, String>(properties);
-        this.kafkaConsumer.subscribe(Collections.singletonList(KafkaInfrastructureConfig.getOrderTopic()));
+		config = new KafkaInfrastructureConfig();
+		kafkaConsumer = new KafkaConsumer<String, String>(properties);
+        this.kafkaConsumer.subscribe(Collections.singletonList(config.getOrderTopic()));
         orderRepository = AppRegistry.getInstance().shippingOrderRepository();	
         this.pollTimeOut = KafkaInfrastructureConfig.CONSUMER_POLL_TIMEOUT;
 		this.closeTimeOut = KafkaInfrastructureConfig.CONSUMER_CLOSE_TIMEOUT;

--- a/order-command-ms/src/main/java/ibm/gse/orderms/infrastructure/kafka/OrderEventProducer.java
+++ b/order-command-ms/src/main/java/ibm/gse/orderms/infrastructure/kafka/OrderEventProducer.java
@@ -38,12 +38,14 @@ public class OrderEventProducer implements EventEmitterTransactional {
 
     private KafkaProducer<String, String> kafkaProducer;
     private Properties properties;
+    private KafkaInfrastructureConfig config;
 
     public OrderEventProducer() {  
-    	initProducer();
+        initProducer();
     }
-
+    
 	private void initProducer() {
+        config = new KafkaInfrastructureConfig();
 		properties = KafkaInfrastructureConfig.getProducerProperties("ordercmd-event-producer");
 		// properties.put(ProducerConfig.ACKS_CONFIG, "1");
         // properties.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, false);
@@ -90,7 +92,7 @@ public class OrderEventProducer implements EventEmitterTransactional {
             key = null;
             value = null;
         }
-        ProducerRecord<String, String> record = new ProducerRecord<>(KafkaInfrastructureConfig.getOrderTopic(), key, value);
+        ProducerRecord<String, String> record = new ProducerRecord<>(config.getOrderTopic(), key, value);
 
         kafkaProducer.beginTransaction();
         Future<RecordMetadata> send = kafkaProducer.send(record);
@@ -131,7 +133,7 @@ public class OrderEventProducer implements EventEmitterTransactional {
             key = null;
             value = null;
         }
-        ProducerRecord<String, String> record = new ProducerRecord<>(KafkaInfrastructureConfig.getOrderTopic(), key, value);
+        ProducerRecord<String, String> record = new ProducerRecord<>(config.getOrderTopic(), key, value);
 
         kafkaProducer.beginTransaction();
         Future<RecordMetadata> send = kafkaProducer.send(record);

--- a/order-command-ms/src/test/java/it/OrderCRUServiceIT.java
+++ b/order-command-ms/src/test/java/it/OrderCRUServiceIT.java
@@ -165,7 +165,7 @@ public class OrderCRUServiceIT extends CommonITTest {
         try(Producer<String, String> producer = new KafkaProducer<>(properties)) {
             String value = new Gson().toJson(event);
             String key = order.getOrderID();
-            ProducerRecord<String, String> record = new ProducerRecord<>(KafkaInfrastructureConfig.getOrderTopic(), key, value);
+            ProducerRecord<String, String> record = new ProducerRecord<>(new KafkaInfrastructureConfig().getOrderTopic(), key, value);
 
             Future<RecordMetadata> future = producer.send(record);
             future.get(10000, TimeUnit.MILLISECONDS);

--- a/order-command-ms/src/test/java/ut/OrderCommandEventProducerMock.java
+++ b/order-command-ms/src/test/java/ut/OrderCommandEventProducerMock.java
@@ -28,9 +28,10 @@ public class OrderCommandEventProducerMock implements EventEmitter{
 		this.eventEmitted = true;
 		this.emittedEvent = (OrderCommandEvent)event;
 		ShippingOrder shippingOrder = new ShippingOrder(emittedEvent.getPayload());
-		// this is the mockup part: use the repo to move the data to consumer
         switch (emittedEvent.getType()) {
-        case OrderCommandEvent.TYPE_CREATE_ORDER:
+		case OrderCommandEvent.TYPE_CREATE_ORDER:
+			// Move to pending state to allow update
+			shippingOrder.setStatus(ShippingOrder.PENDING_STATUS);
         	repo.addOrUpdateNewShippingOrder(shippingOrder);			
             break;
         case OrderCommandEvent.TYPE_UPDATE_ORDER:

--- a/order-command-ms/src/test/java/ut/OrderEventEmitterMock.java
+++ b/order-command-ms/src/test/java/ut/OrderEventEmitterMock.java
@@ -36,8 +36,7 @@ public class OrderEventEmitterMock implements EventEmitterTransactional {
 	@Override
 	public void emitWithOffsets(EventBase event, Map<TopicPartition, OffsetAndMetadata> offsetToCommit,
 			String groupID) throws Exception {
-		// TODO Auto-generated method stub
-
+		emit(event);
 	}
 
 	@Override

--- a/order-command-ms/src/test/java/ut/TestReadinessLiveness.java
+++ b/order-command-ms/src/test/java/ut/TestReadinessLiveness.java
@@ -10,11 +10,13 @@ import ibm.gse.orderms.app.StarterLivenessCheck;
 import ibm.gse.orderms.app.StarterReadinessCheck;
 import ibm.gse.orderms.domain.model.order.ShippingOrder;
 import ibm.gse.orderms.infrastructure.command.events.OrderCommandEvent;
+import ibm.gse.orderms.infrastructure.kafka.KafkaInfrastructureConfig;
 import ibm.gse.orderms.infrastructure.kafka.OrderCommandAgent;
 import ibm.gse.orderms.infrastructure.kafka.OrderEventAgent;
 import ibm.gse.orderms.infrastructure.repository.ShippingOrderRepository;
 import ibm.gse.orderms.infrastructure.repository.ShippingOrderRepositoryMock;
 
+import static org.mockito.Mockito.*;
 
 public class TestReadinessLiveness {
 
@@ -32,7 +34,9 @@ public class TestReadinessLiveness {
 		orderEventProducerMock = new OrderEventEmitterMock();
 		ShippingOrderRepository repository = new ShippingOrderRepositoryMock();
 		OrderEventEmitterMock errorEventProducerMock = new OrderEventEmitterMock();
-		commandAgent = new OrderCommandAgent(repository,consumerMock,orderEventProducerMock,errorEventProducerMock);
+		KafkaInfrastructureConfig config = mock(KafkaInfrastructureConfig.class);
+		when (config.getOrderCommandTopic()).thenReturn("order-command");
+		commandAgent = new OrderCommandAgent(repository,consumerMock,orderEventProducerMock,errorEventProducerMock,config);
 		OrderEventAgent eventAgent = new OrderEventAgent(consumerMock,repository);
 		liveness = new StarterLivenessCheck(commandAgent,eventAgent);
 		readiness = new StarterReadinessCheck(commandAgent,eventAgent);

--- a/order-command-ms/src/test/java/ut/gse/orderms/domain/service/TestOrderService.java
+++ b/order-command-ms/src/test/java/ut/gse/orderms/domain/service/TestOrderService.java
@@ -17,6 +17,7 @@ import ibm.gse.orderms.domain.service.ShippingOrderService;
 import ibm.gse.orderms.infrastructure.command.events.OrderCommandEvent;
 import ibm.gse.orderms.infrastructure.events.EventBase;
 import ibm.gse.orderms.infrastructure.events.order.OrderEventPayload;
+import ibm.gse.orderms.infrastructure.kafka.KafkaInfrastructureConfig;
 import ibm.gse.orderms.infrastructure.kafka.OrderCommandAgent;
 import ibm.gse.orderms.infrastructure.repository.OrderUpdateException;
 import ibm.gse.orderms.infrastructure.repository.ShippingOrderRepository;
@@ -25,6 +26,8 @@ import ut.KafkaConsumerMockup;
 import ut.OrderCommandEventProducerMock;
 import ut.OrderEventEmitterMock;
 import ut.ShippingOrderTestDataFactory;
+
+import static org.mockito.Mockito.*; 
 
 public class TestOrderService {
 
@@ -132,7 +135,9 @@ public class TestOrderService {
 		OrderEventEmitterMock orderEventEmitter = new OrderEventEmitterMock();
 		OrderEventEmitterMock errorEventEmitter = new OrderEventEmitterMock();
 		// agent consume command events and generate order event
-		OrderCommandAgent orderCommandAgent = new OrderCommandAgent(orderRepository,kcm,orderEventEmitter,errorEventEmitter);
+		KafkaInfrastructureConfig config = mock(KafkaInfrastructureConfig.class);
+		when (config.getOrderCommandTopic()).thenReturn("order-command");
+		OrderCommandAgent orderCommandAgent = new OrderCommandAgent(orderRepository,kcm,orderEventEmitter,errorEventEmitter,config);
 
 		// need mockup emitter
 		OrderCommandEventProducerMock eventEmitter = new OrderCommandEventProducerMock(orderRepository);

--- a/order-command-ms/src/test/java/ut/orderms/app/TestOrderResource.java
+++ b/order-command-ms/src/test/java/ut/orderms/app/TestOrderResource.java
@@ -15,6 +15,7 @@ import ibm.gse.orderms.domain.model.order.ShippingOrder;
 import ibm.gse.orderms.domain.service.ShippingOrderService;
 import ibm.gse.orderms.infrastructure.AppRegistry;
 import ibm.gse.orderms.infrastructure.events.EventEmitter;
+import ibm.gse.orderms.infrastructure.events.order.OrderEventPayload;
 import ibm.gse.orderms.infrastructure.repository.ShippingOrderRepository;
 import ibm.gse.orderms.infrastructure.repository.ShippingOrderRepositoryMock;
 import ut.OrderCommandEventProducerMock;
@@ -53,7 +54,8 @@ public class TestOrderResource  {
 		Response rep = resource.createShippingOrder(orderDTO);
 		Assert.assertNotNull(rep);
 		Assert.assertTrue(rep.getStatus() == 200);	
-		String orderID=((String)rep.getEntity());
+		OrderEventPayload payload = (OrderEventPayload) rep.getEntity();
+		String orderID = payload.getOrderID();
 		Assert.assertNotNull(orderID);
 		// in fact we do not need to validate the repository as it should be done within the service testing
 		Optional<ShippingOrder> order =orderRepository.getOrderByOrderID(orderID);
@@ -66,7 +68,8 @@ public class TestOrderResource  {
 		// prepare data for test
 		ShippingOrderCreateParameters orderDTO = ShippingOrderTestDataFactory.orderCreateFixtureWithoutID();
 		Response rep = resource.createShippingOrder(orderDTO);
-		String orderID=((String)rep.getEntity());
+		OrderEventPayload payload = (OrderEventPayload) rep.getEntity();
+		String orderID = payload.getOrderID();
 		Assert.assertNotNull(orderID);
 		// Get the shipping order
 		ShippingOrder existingOrder = (ShippingOrder)resource.getOrderByOrderId(orderID).getEntity();

--- a/order-command-ms/src/test/java/ut/orderms/infrastructure/TestOrderCommandAgent.java
+++ b/order-command-ms/src/test/java/ut/orderms/infrastructure/TestOrderCommandAgent.java
@@ -252,10 +252,10 @@ public class TestOrderCommandAgent {
 				+ "\"type\":\"CreateOrderCommand\"}");
 		orderCommandsConsumerMock.setKey("Order01");
 		// List<OrderCommandEvent> results = agent.poll();
-		agent.poll();
-		// OrderCommandEvent createOrderEvent = results.get(0);
 		// inject communication error in kafka
 		orderEventProducerMock.failure = true;
+		agent.poll();
+		// OrderCommandEvent createOrderEvent = results.get(0);
 		// agent.handle(createOrderEvent);
 		Assert.assertFalse(orderEventProducerMock.eventEmitted);
 		Assert.assertFalse(errorEventProducerMock.eventEmitted);
@@ -275,10 +275,11 @@ public class TestOrderCommandAgent {
 				+ "\"type\":\"UpdateOrderCommand\"}");
 		orderCommandsConsumerMock.setKey("Order01");
 		// List<OrderCommandEvent> results = agent.poll();
-		agent.poll();
-		// OrderCommandEvent updateOrderEvent = results.get(0);
 		// inject communication error in kafka
 		orderEventProducerMock.failure = true;
+		
+		agent.poll();
+		// OrderCommandEvent updateOrderEvent = results.get(0);
 		// agent.handle(updateOrderEvent);
 		Assert.assertFalse(orderEventProducerMock.eventEmitted);
 		Assert.assertFalse(errorEventProducerMock.eventEmitted);

--- a/order-command-ms/src/test/java/ut/orderms/infrastructure/TestOrderCommandAgent.java
+++ b/order-command-ms/src/test/java/ut/orderms/infrastructure/TestOrderCommandAgent.java
@@ -1,6 +1,7 @@
 package ut.orderms.infrastructure;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,10 +13,12 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+
 import ibm.gse.orderms.domain.model.order.ShippingOrder;
 import ibm.gse.orderms.infrastructure.command.events.OrderCommandEvent;
 import ibm.gse.orderms.infrastructure.events.order.OrderEvent;
 import ibm.gse.orderms.infrastructure.kafka.ErrorEvent;
+import ibm.gse.orderms.infrastructure.kafka.KafkaInfrastructureConfig;
 import ibm.gse.orderms.infrastructure.kafka.OrderCommandAgent;
 import ibm.gse.orderms.infrastructure.repository.ShippingOrderRepositoryMock;
 import ut.KafkaConsumerMockup;
@@ -42,6 +45,7 @@ public class TestOrderCommandAgent {
 	static KafkaConsumerMockup<String,String> orderCommandsConsumerMock = null;
 	static OrderEventEmitterMock orderEventProducerMock = null;
 	static OrderEventEmitterMock errorEventProducerMock = null;
+	private static KafkaInfrastructureConfig config;
 
 	@BeforeClass
 	public static void createMockups() {
@@ -56,11 +60,14 @@ public class TestOrderCommandAgent {
 			errorEventProducerMock = new OrderEventEmitterMock();
 		}
 		repository = new ShippingOrderRepositoryMock();
+		config = mock(KafkaInfrastructureConfig.class);
+		when (config.getOrderCommandTopic()).thenReturn("order-command");
+		
 	}
 
 	@Before
 	public void createAgent() {
-		agent = new OrderCommandAgent(repository,orderCommandsConsumerMock,orderEventProducerMock,errorEventProducerMock);
+		agent = new OrderCommandAgent(repository,orderCommandsConsumerMock,orderEventProducerMock,errorEventProducerMock,config);
 	}
 
 	@After

--- a/order-command-ms/src/test/java/ut/orderms/infrastructure/TestOrderEventAgent.java
+++ b/order-command-ms/src/test/java/ut/orderms/infrastructure/TestOrderEventAgent.java
@@ -1,5 +1,8 @@
 package ut.orderms.infrastructure;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -122,7 +125,7 @@ public class TestOrderEventAgent {
 		ShippingOrder order = ShippingOrderTestDataFactory.orderFixtureWithIdentity();
 		repository.addOrUpdateNewShippingOrder(order);
 		String voyageEvent = "{\"timestamp\": " + new Date().getTime() 
-		    		+ ",\"type\": \"ContainerAssigned\", \"version\": \"1\"," 
+		    		+ ",\"type\": \"ContainerAllocated\", \"version\": \"1\"," 
 		    		+ " \"payload\": { \"containerID\": \"C01\",\"orderID\": \"" + order.getOrderID()
 		    		+ "\"}}";
 		orderEventsConsumerMock.setValue(voyageEvent);
@@ -133,7 +136,8 @@ public class TestOrderEventAgent {
 			agent.handle(event);
 		}
 		Optional<ShippingOrder> orderOption = repository.getOrderByOrderID(order.getOrderID());
-		Assert.assertTrue("C01".equals(orderOption.get().getContainerID()));	
+		assertTrue("Order not found in repository", orderOption.isPresent());
+		assertEquals("C01",orderOption.get().getContainerID());	
 	}
 
 }


### PR DESCRIPTION
When starting to move order-command-ms to Appsody, we noticed that the unit tests were already broken.   I was keen to have these working to help us validate the conversion, so I've spent some time to fix them up.  Here's what I had to change:

- Avoid using MicroProfile Config in the tests. 
    Topic names are retrieved from `KafkaInfrastructureConfig` which was loading configuration using MicroProfile Config.  This is not going to work in a unit test as there won't be an mpConfig implementation available. So I've modified all the users to create an instance of `KafkaInstructureConfig`, so I can then inject a mocked implementation in the tests.
- Modify `OrderEventEmitterMock` to capture events emitted when `emitWithOffsets()` is called - otherwise the tests don't see these events being emitted.
- Reorder things in `TestOrderCommandAgent` to set up inject failures *before* calling `agent.poll()` to make sure the failures occur
- Update a 'ContainerAllocated' event in `TestOrderEventAgent` to match the new name
- In `TestOrderResource`, extract an `OrderEventPayload` from the response in order to get hold of the order ID
- In `OrderCommandEventProducerMock`,  put created orders in the 'PENDING' state to allow them to be update (for the update test in TestOrderResource)

Now these are working it would be good to maintain them. Therefore I've updated the Dockerfile to run the unit tests, but skip the integration tests.