### PR TITLE
Fix order-query integration tests

### DIFF
--- a/order-query-ms/src/main/java/ibm/gse/orderqueryms/infrastructure/kafka/ApplicationConfig.java
+++ b/order-query-ms/src/main/java/ibm/gse/orderqueryms/infrastructure/kafka/ApplicationConfig.java
@@ -23,7 +23,7 @@ public class ApplicationConfig {
 
 	private static final Logger logger = LoggerFactory.getLogger(ApplicationConfig.class.getName());
 	
-    private static Config config = ConfigProvider.getConfig();
+    private Config config; 
 
     private static String ORDER_TOPIC;
     
@@ -37,19 +37,28 @@ public class ApplicationConfig {
     public static final long PRODUCER_CLOSE_TIMEOUT_SEC = 10;
     public static final long TERMINATION_TIMEOUT_SEC = 10;
 
-    public static String getOrderTopic() {
+
+    public ApplicationConfig() {
+        config = ConfigProvider.getConfig();
+    }
+
+    public ApplicationConfig(Config config) {
+        this.config = config;
+    }
+
+    public String getOrderTopic() {
     	ORDER_TOPIC = config.getValue("order.topic", String.class);
     	logger.info("Get Order Topic: {}", ORDER_TOPIC);
 		return ORDER_TOPIC;
 	}
     
-    public static String getContainerTopic() {
+    public String getContainerTopic() {
     	CONTAINER_TOPIC = config.getValue("container.topic", String.class);
     	logger.info("Get Container Topic: {}", CONTAINER_TOPIC);
 		return CONTAINER_TOPIC;
 	}
     
-	public static String getErrorTopic() {
+	public String getErrorTopic() {
 		ERROR_TOPIC = config.getValue("error.topic",  String.class);
     	logger.info("Get Error Topic: {}", ERROR_TOPIC);
 		return ERROR_TOPIC;

--- a/order-query-ms/src/main/java/ibm/gse/orderqueryms/infrastructure/kafka/ContainerAgent.java
+++ b/order-query-ms/src/main/java/ibm/gse/orderqueryms/infrastructure/kafka/ContainerAgent.java
@@ -38,7 +38,7 @@ public class ContainerAgent implements EventListener {
     public ContainerAgent() {
         Properties properties = ApplicationConfig.getContainerConsumerProperties("orderquery-container-consumer");
         kafkaConsumer = new KafkaConsumer<String, String>(properties);
-		this.kafkaConsumer.subscribe(Collections.singletonList(ApplicationConfig.getContainerTopic()));
+		this.kafkaConsumer.subscribe(Collections.singletonList(new ApplicationConfig().getContainerTopic()));
 
 		orderHistoryRepository = AppRegistry.getInstance().orderHistoryRepository();
     }

--- a/order-query-ms/src/main/java/ibm/gse/orderqueryms/infrastructure/kafka/ErrorProducer.java
+++ b/order-query-ms/src/main/java/ibm/gse/orderqueryms/infrastructure/kafka/ErrorProducer.java
@@ -34,7 +34,7 @@ public class ErrorProducer implements EventEmitter {
         ErrorEvent errorEvent = (ErrorEvent) event;
         String value = new Gson().toJson(errorEvent);
 
-        ProducerRecord<String, String> record = new ProducerRecord<>(ApplicationConfig.getErrorTopic(), value);
+        ProducerRecord<String, String> record = new ProducerRecord<>(new ApplicationConfig().getErrorTopic(), value);
 
         Future<RecordMetadata> send = kafkaProducer.send(record);
         send.get(ApplicationConfig.PRODUCER_TIMEOUT_SECS, TimeUnit.SECONDS);

--- a/order-query-ms/src/main/java/ibm/gse/orderqueryms/infrastructure/kafka/OrderAgent.java
+++ b/order-query-ms/src/main/java/ibm/gse/orderqueryms/infrastructure/kafka/OrderAgent.java
@@ -48,7 +48,7 @@ public class OrderAgent implements EventListener {
 	public OrderAgent() {
 		Properties properties = ApplicationConfig.getOrderConsumerProperties("orderquery-orders-consumer");
 		kafkaConsumer = new KafkaConsumer<String, String>(properties);
-		this.kafkaConsumer.subscribe(Collections.singletonList(ApplicationConfig.getOrderTopic()));
+		this.kafkaConsumer.subscribe(Collections.singletonList(new ApplicationConfig().getOrderTopic()));
 
 		orderRepository = AppRegistry.getInstance().orderRepository();
 		orderHistoryRepository = AppRegistry.getInstance().orderHistoryRepository();

--- a/order-query-ms/src/test/java/it/OrderActionServiceIT.java
+++ b/order-query-ms/src/test/java/it/OrderActionServiceIT.java
@@ -17,6 +17,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -48,6 +49,13 @@ public class OrderActionServiceIT {
     private String endpoint = "/orders/";
     private String url = "http://localhost:" + port + endpoint;
 
+    private ApplicationConfig config;
+
+    @Before
+    public void setupApplicationConfig() {
+        config = new ApplicationConfig(new TestApplicationConfig());
+    }
+
     @Test
     public void testOrderStatusNoAvailability() throws Exception {
 
@@ -58,12 +66,12 @@ public class OrderActionServiceIT {
     	                addr, "2019-02-10T13:30Z",
     	                addr, "2019-02-10T13:30Z", Order.PENDING_STATUS);
     	OrderEvent ord_event = new CreateOrderEvent(System.currentTimeMillis(), "1", order);
-    	sendEvent("testOrderStatusNoAvailability", ApplicationConfig.getOrderTopic(), orderID, new Gson().toJson(ord_event));
+    	sendEvent("testOrderStatusNoAvailability", config.getOrderTopic(), orderID, new Gson().toJson(ord_event));
 
         CancelAndRejectPayload rejectionPayload = new CancelAndRejectPayload(orderID, "productId", "custId", "contId", "voyId", 2, addr, "2019-02-10T13:30Z", addr, "2019-02-10T13:30Z", "rejected", "A container was not found");
 
     	OrderEvent ord_event2 = new RejectOrderEvent(System.currentTimeMillis(), "1", rejectionPayload);
-    	sendEvent("testOrderStatusNoAvailability", ApplicationConfig.getOrderTopic(), orderID, new Gson().toJson(ord_event2));
+    	sendEvent("testOrderStatusNoAvailability", config.getOrderTopic(), orderID, new Gson().toJson(ord_event2));
 
     	OrderHistoryInfo expectedOrder = OrderHistoryInfo.newFromOrder(order);
     	expectedOrder.reject(rejectionPayload);
@@ -94,49 +102,49 @@ public class OrderActionServiceIT {
                 addr, "2019-01-10T13:30Z",
                 addr, "2019-01-10T13:30Z", Order.PENDING_STATUS);
         OrderEvent ord_event = new CreateOrderEvent(System.currentTimeMillis(), "1", order);
-        sendEvent("testOrderStatus", ApplicationConfig.getOrderTopic(), orderID, new Gson().toJson(ord_event));
+        sendEvent("testOrderStatus", config.getOrderTopic(), orderID, new Gson().toJson(ord_event));
 
         OrderHistoryInfo expectedOrder = OrderHistoryInfo.newFromOrder(order);
 
         VoyageAssignment va = new VoyageAssignment(orderID, "myVoyage");
         OrderEvent ord_event2 = new AssignOrderEvent(System.currentTimeMillis(), "1", va);
-        sendEvent("testOrderStatus", ApplicationConfig.getOrderTopic(), orderID, new Gson().toJson(ord_event2));
+        sendEvent("testOrderStatus", config.getOrderTopic(), orderID, new Gson().toJson(ord_event2));
 
         expectedOrder.assignVoyage(va);
 
         ContainerAssignment container = new ContainerAssignment(orderID, containerID);
         OrderEvent ord_event3 = new AssignContainerEvent(System.currentTimeMillis(), "1", orderID, container);
-        sendEvent("testOrderStatus", ApplicationConfig.getOrderTopic(), orderID, new Gson().toJson(ord_event3));
+        sendEvent("testOrderStatus", config.getOrderTopic(), orderID, new Gson().toJson(ord_event3));
 
         expectedOrder.assignContainer(container);
 
         Container cont = new Container(containerID, "brand", "type", 1, 1, 1, "ContainerAdded");
         ContainerEvent cont_event = new ContainerAddedEvent(System.currentTimeMillis(), "1", cont);
-        sendEvent("testOrderStatus", ApplicationConfig.getContainerTopic(), containerID, new Gson().toJson(cont_event));
+        sendEvent("testOrderStatus", config.getContainerTopic(), containerID, new Gson().toJson(cont_event));
 
         OrderHistoryInfo expectedContainer = OrderHistoryInfo.newFromContainer(cont);
 
         // cont.setStatus("ContainerAtLocation");
         // ContainerEvent cont_event2 = new ContainerAtLocationEvent(System.currentTimeMillis(), "1", cont);
-        // sendEvent("testOrderStatus", ApplicationConfig.getContainerTopic(), containerID, new Gson().toJson(cont_event2));
+        // sendEvent("testOrderStatus", config.getContainerTopic(), containerID, new Gson().toJson(cont_event2));
 
         // expectedContainer.containerAtLocation(cont);
 
         cont.setStatus("ContainerOnMaintenance");
         ContainerEvent cont_event3 = new ContainerOnMaintenanceEvent(System.currentTimeMillis(), "1", cont);
-        sendEvent("testOrderStatus", ApplicationConfig.getContainerTopic(), containerID, new Gson().toJson(cont_event3));
+        sendEvent("testOrderStatus", config.getContainerTopic(), containerID, new Gson().toJson(cont_event3));
 
         expectedContainer.containerOnMaintenance(cont);
         
         cont.setStatus("ContainerOffMaintenance");
         ContainerEvent cont_event4 = new ContainerOffMaintenanceEvent(System.currentTimeMillis(), "1", cont);
-        sendEvent("testOrderStatus", ApplicationConfig.getContainerTopic(), containerID, new Gson().toJson(cont_event4));
+        sendEvent("testOrderStatus", config.getContainerTopic(), containerID, new Gson().toJson(cont_event4));
 
         expectedContainer.containerOffMaintenance(cont);
         
         cont.setStatus("ContainerAssignedToOrder");
         ContainerEvent cont_event5 = new ContainerOrderAssignedEvent(System.currentTimeMillis(), "1", cont);
-        sendEvent("testOrderStatus", ApplicationConfig.getContainerTopic(), containerID, new Gson().toJson(cont_event5));
+        sendEvent("testOrderStatus", config.getContainerTopic(), containerID, new Gson().toJson(cont_event5));
 
         expectedContainer.containerOrderAssignment(cont);
 

--- a/order-query-ms/src/test/java/it/TestApplicationConfig.java
+++ b/order-query-ms/src/test/java/it/TestApplicationConfig.java
@@ -1,0 +1,42 @@
+package it;
+
+import ibm.gse.orderqueryms.infrastructure.kafka.ApplicationConfig;
+
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+public class TestApplicationConfig implements Config {
+
+    @Override
+    public String getValue(String propertyName, Class propertyType) {
+        switch (propertyName) {
+            case "order.topic":
+            return "orders";
+            case "container.topic":
+            return "containers";
+            default:
+            return null;
+        }
+
+    }   
+
+    @Override
+    public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Iterable<String> getPropertyNames() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Iterable<ConfigSource> getConfigSources() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+}


### PR DESCRIPTION
Fix up broken integration tests for order-query ms. Changes:

- Avoid using mpConfig in tests
    The tests were trying to use ApplicationConfig, which tries to load a Config from mpConfig in a static initializer. As there's no mpConfig implementation available to the tests, this was failing.  I've refactored to pass in a dummy Config instead for the tests.
- Combine tests for container allocated and voyage assigned
    OrderQueryIT had two separate test cases for states where the container had been allocated and the voyage assigned. The service now only has a single `assigned` state when both the container and voyage have been assigned. So I merged these into a single test case which has both preconditions.

Note there's still something funny about how the Maven plugin starts the server for the integration tests.  The app doesn't get properly installed.  So to get them to work, I've had to run the tests, see them fail, then manually copy `order-query-ms/target/orderqueryms-1.0-SNAPSHOT.war` to `order-query-ms/target/liberty/wlp/usr/servers/defaultServer/apps`.   We'll shortly be appsodifying this service and will sort this out in the process, it didn't seem worth putting effort into this at the moment. 
 You also need to set the `KAFKA_BROKERS` environment variable. I start a Kafka using Docker Compose for this.
Once these steps have been performed, all the tests pass.