### PR TITLE
SCRAM credentials for ES v10

### DIFF
--- a/order-command-ms/chart/ordercommandms/templates/deployment.yaml
+++ b/order-command-ms/chart/ordercommandms/templates/deployment.yaml
@@ -64,17 +64,25 @@ spec:
                 name: "{{ .Values.kafka.topicsConfigMap }}"
                 key: errorsTopic
           {{- if .Values.eventstreams.enabled }}
-          - name: KAFKA_APIKEY
+          - name: KAFKA_USER
             valueFrom:
               secretKeyRef:
-                name: "{{ .Values.eventstreams.apikeyConfigMap }}"
-                key: binding
+                name: "{{ .Values.eventstreams.esCredSecret }}"
+                key: username
+          - name: KAFKA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.eventstreams.esCredSecret }}"
+                key: password
           {{- end }}
           {{- if .Values.eventstreams.truststoreRequired }}
           - name: TRUSTSTORE_ENABLED
             value: "{{ .Values.eventstreams.truststoreRequired }}"
           - name: TRUSTSTORE_PWD
-            value: "{{ .Values.eventstreams.truststorePassword }}"
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.eventstreams.truststorePasswordSecret }}"
+                key: password
           - name: TRUSTSTORE_PATH
             value: "{{ .Values.eventstreams.truststorePath }}/{{ .Values.eventstreams.truststoreFile }}"
           {{- end }}

--- a/order-command-ms/chart/ordercommandms/values.yaml
+++ b/order-command-ms/chart/ordercommandms/values.yaml
@@ -41,10 +41,10 @@ kafka:
   topicsConfigMap: kafka-topics
 eventstreams:
   enabled: true
-  apikeyConfigMap: eventstreams-apikey
+  esCredSecret: eventstreams-cred
   truststoreRequired: false
   truststorePath: /config/resources/security/es-ssl
-  truststoreFile: es-cert.jks
-  truststoreSecret: es-truststore-jks
-  truststorePassword: password
+  truststoreFile: es-cert.p12
+  truststoreSecret: eventstreams-truststore
+  truststorePasswordSecret: eventstreams-truststore-pwd
 serviceAccountName: default

--- a/order-command-ms/src/main/java/ibm/gse/orderms/infrastructure/kafka/KafkaInfrastructureConfig.java
+++ b/order-command-ms/src/main/java/ibm/gse/orderms/infrastructure/kafka/KafkaInfrastructureConfig.java
@@ -98,15 +98,22 @@ public class KafkaInfrastructureConfig {
 		}
 		properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, env.get("KAFKA_BROKERS"));
 
-		if (env.get("KAFKA_APIKEY") != null && !env.get("KAFKA_APIKEY").isEmpty()) {
+		if (env.get("KAFKA_USER") != null && !env.get("KAFKA_USER").isEmpty() && env.get("KAFKA_PASSWORD") != null && !env.get("KAFKA_PASSWORD").isEmpty()) {
 			properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-			properties.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
-			properties.put(SaslConfigs.SASL_JAAS_CONFIG,
-					"org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\""
-							+ env.get("KAFKA_APIKEY") + "\";");
 			properties.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
 			properties.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, "TLSv1.2");
 			properties.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
+			// If we are connecting to ES on IBM Cloud, the SASL mechanism is plain
+			if ("token".equals(env.get("KAFKA_USER"))) {
+				properties.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+				properties.put(SaslConfigs.SASL_JAAS_CONFIG,"org.apache.kafka.common.security.plain.PlainLoginModule required username=\"" + env.get("KAFKA_USER") + "\" password=\"" + env.get("KAFKA_PASSWORD") + "\";");
+			}
+			// If we are connecting to ES on OCP, the SASL mechanism is scram-sha-512
+			else {
+				properties.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG,"PKCS12");
+				properties.put(SaslConfigs.SASL_MECHANISM, "SCRAM-SHA-512");
+				properties.put(SaslConfigs.SASL_JAAS_CONFIG,"org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + env.get("KAFKA_USER") + "\" password=\"" + env.get("KAFKA_PASSWORD") + "\";");
+			}
 
 			if ("true".equals(env.get("TRUSTSTORE_ENABLED"))){
 				properties.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, env.get("TRUSTSTORE_PATH"));

--- a/order-query-ms/chart/orderqueryms/templates/deployment.yaml
+++ b/order-query-ms/chart/orderqueryms/templates/deployment.yaml
@@ -64,17 +64,25 @@ spec:
                 name: "{{ .Values.kafka.topicsConfigMap }}"
                 key: errorsTopic
           {{- if .Values.eventstreams.enabled }}
-          - name: KAFKA_APIKEY
+          - name: KAFKA_USER
             valueFrom:
               secretKeyRef:
-                name: "{{ .Values.eventstreams.apikeyConfigMap }}"
-                key: binding
+                name: "{{ .Values.eventstreams.esCredSecret }}"
+                key: username
+          - name: KAFKA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.eventstreams.esCredSecret }}"
+                key: password
           {{- end }}
           {{- if .Values.eventstreams.truststoreRequired }}
           - name: TRUSTSTORE_ENABLED
             value: "{{ .Values.eventstreams.truststoreRequired }}"
           - name: TRUSTSTORE_PWD
-            value: "{{ .Values.eventstreams.truststorePassword }}"
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.eventstreams.truststorePasswordSecret }}"
+                key: password
           - name: TRUSTSTORE_PATH
             value: "{{ .Values.eventstreams.truststorePath }}/{{ .Values.eventstreams.truststoreFile }}"
           {{- end }}

--- a/order-query-ms/chart/orderqueryms/values.yaml
+++ b/order-query-ms/chart/orderqueryms/values.yaml
@@ -41,10 +41,10 @@ kafka:
   topicsConfigMap: kafka-topics
 eventstreams:
   enabled: true
-  apikeyConfigMap: eventstreams-apikey
+  esCredSecret: eventstreams-cred
   truststoreRequired: false
   truststorePath: /config/resources/security/es-ssl
-  truststoreFile: es-cert.jks
-  truststoreSecret: es-truststore-jks
-  truststorePassword: password
+  truststoreFile: es-cert.p12
+  truststoreSecret: eventstreams-truststore
+  truststorePasswordSecret: eventstreams-truststore-pwd
 serviceAccountName: default

--- a/order-query-ms/src/main/java/ibm/gse/orderqueryms/infrastructure/kafka/ApplicationConfig.java
+++ b/order-query-ms/src/main/java/ibm/gse/orderqueryms/infrastructure/kafka/ApplicationConfig.java
@@ -134,20 +134,26 @@ public class ApplicationConfig {
         }
         properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, env.get("KAFKA_BROKERS"));
 
-    		if (env.get("KAFKA_APIKEY") != null && !env.get("KAFKA_APIKEY").isEmpty()) {
-          properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-          properties.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
-          properties.put(SaslConfigs.SASL_JAAS_CONFIG,
-                    "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\""
-                            + env.get("KAFKA_APIKEY") + "\";");
-          properties.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
-          properties.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, "TLSv1.2");
-          properties.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
+    	if (env.get("KAFKA_USER") != null && !env.get("KAFKA_USER").isEmpty() && env.get("KAFKA_PASSWORD") != null && !env.get("KAFKA_PASSWORD").isEmpty()) {
+            properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+            properties.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
+            properties.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, "TLSv1.2");
+            properties.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
+            // If we are connecting to ES on IBM Cloud, the SASL mechanism is plain
+			if ("token".equals(env.get("KAFKA_USER"))) {
+				properties.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+				properties.put(SaslConfigs.SASL_JAAS_CONFIG,"org.apache.kafka.common.security.plain.PlainLoginModule required username=\"" + env.get("KAFKA_USER") + "\" password=\"" + env.get("KAFKA_PASSWORD") + "\";");
+			}
+			// If we are connecting to ES on OCP, the SASL mechanism is scram-sha-512
+			else {
+				properties.put(SaslConfigs.SASL_MECHANISM, "SCRAM-SHA-512");
+				properties.put(SaslConfigs.SASL_JAAS_CONFIG,"org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + env.get("KAFKA_USER") + "\" password=\"" + env.get("KAFKA_PASSWORD") + "\";");
+			}
 
-          if ("true".equals(env.get("TRUSTSTORE_ENABLED"))){
-            properties.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, env.get("TRUSTSTORE_PATH"));
-            properties.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, env.get("TRUSTSTORE_PWD"));
-          }
+            if ("true".equals(env.get("TRUSTSTORE_ENABLED"))){
+                properties.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, env.get("TRUSTSTORE_PATH"));
+                properties.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, env.get("TRUSTSTORE_PWD"));
+            }
         }
 
         return properties;


### PR DESCRIPTION
Refactoring to allow new authentication mechanism in ES v10 that uses SCRAM. There is also some refactoring on the names for the secrets/configmaps that this microservices will be loading config from.

This is one of the changes suggested in ibm-cloud-architecture/refarch-kc#119